### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     branches: [ "main" ]


### PR DESCRIPTION
Potential fix for [https://github.com/Div0011/mowglai/security/code-scanning/4](https://github.com/Div0011/mowglai/security/code-scanning/4)

In general, fix this by adding a `permissions` block that grants only the scopes actually required by the workflow, either at the workflow root (applies to all jobs) or at the individual job level. For a basic CI workflow that only checks out code and runs Node commands, `contents: read` is usually sufficient.

For this specific file `.github/workflows/CI.yml`, the simplest fix without changing functionality is to add a root-level `permissions` block just under the `name: CI` line. Since none of the steps require write access to the repository or to PRs, we can safely set `contents: read` as the only permission. This will constrain the `GITHUB_TOKEN` used by `actions/checkout` and any other steps to read-only repository contents, which is enough for checkouts and dependency installation from the repo. No additional imports or methods are needed; this is purely a YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

CI:
- Add a root-level permissions block to the CI workflow to limit GITHUB_TOKEN access to read-only repository contents.