### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/Div0011/mowglai/security/code-scanning/1](https://github.com/Div0011/mowglai/security/code-scanning/1)

In general, the fix is to explicitly define a `permissions:` block for the workflow or for the specific job so that the GITHUB_TOKEN has only the minimal required permissions. Since this workflow only checks out code and then builds and deploys via SSH, it likely only needs read access to repository contents.

The best way to fix this without changing existing functionality is to add a job-level `permissions:` block under `jobs.deploy:` that sets `contents: read`. This ensures the `deploy` job’s GITHUB_TOKEN can read repository contents (needed by `actions/checkout@v4`) but cannot write to the repository or perform unnecessary actions. No additional methods, imports, or libraries are required—this is purely a YAML configuration change in `.github/workflows/deploy.yml`.

Concretely, edit `.github/workflows/deploy.yml` around line 10 to insert:

```yaml
    permissions:
      contents: read
```

indented at the same level as `runs-on:` so it applies to the `deploy` job.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

CI:
- Add an explicit permissions block to the deploy job so its GITHUB_TOKEN has read-only access to repository contents.