### PR TITLE
Potential fix for code scanning alert no. 5: DOM text reinterpreted as HTML

### DIFF
--- a/app/referral/page.tsx
+++ b/app/referral/page.tsx
@@ -164,7 +164,7 @@ export default function ReferralPage() {
                                                 onClick={() => {
                                                     const subject = encodeURIComponent(`${userData.name} has a gift for you!`);
                                                     const body = encodeURIComponent(`Hey ${friendData.name},\n\nYour friend ${userData.name} thinks you'd love Mowglai! We build digital experiences that perform, inspire, and grow.\n\nUse this referral code: MOW10-DISCOUNT to get 10% OFF your first project.\n\nLet's build something extraordinary together.\n\nCheers,\nThe Mowglai Team`);
-                                                    window.location.href = `mailto:${friendData.email}?subject=${subject}&body=${body}`;
+                                                    window.location.href = `mailto:${encodeURIComponent(friendData.email)}?subject=${subject}&body=${body}`;
                                                 }}
                                                 className="bg-primary text-primary-foreground hover:scale-105 active:scale-95 transition-all font-display font-bold px-10 py-7 rounded-full uppercase tracking-widest text-xs w-full shadow-[0_20px_40px_rgba(var(--primary-rgb),0.3)]"
                                             >


### PR DESCRIPTION
Potential fix for [https://github.com/Div0011/mowglai/security/code-scanning/5](https://github.com/Div0011/mowglai/security/code-scanning/5)

In general, to fix this kind of problem you ensure that any untrusted data included in a URL or HTML context is properly encoded/escaped for that context, or you validate it against a strict allowlist. Here, the issue is that `friendData.email` (user input) is interpolated raw into the `mailto:` URL string passed to `window.location.href`, while `subject` and `body` are already passed through `encodeURIComponent`.

The best minimal and behavior-preserving fix is to URL-encode the email address before including it in the `mailto:` URL. This ensures that any characters an attacker might try to inject (such as `?`, `&`, or control characters) are encoded and cannot break out of the intended email-local-part/host context or alter the rest of the URL. Concretely, in `app/referral/page.tsx`, within the `onClick` handler for the "Launch Email Client" button, we should wrap `friendData.email` in `encodeURIComponent(...)` when building the `mailto:` string. No new imports or helper functions are needed.

Specifically:
- In `app/referral/page.tsx`, around line 165–168, change:
  - `window.location.href = \`mailto:${friendData.email}?subject=${subject}&body=${body}\`;`
- To:
  - `window.location.href = \`mailto:${encodeURIComponent(friendData.email)}?subject=${subject}&body=${body}\`;`

This keeps all functionality (launching the email client with prefilled recipient, subject, and body) intact while ensuring the entire URL is correctly encoded.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Bug Fixes:
- Sanitize the recipient email in the referral mailto link by encoding it before assigning to window.location.href to address a code scanning security alert.