### PR TITLE
fix: restore CI/CD but restrict only deploy step to Div0011

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -10,7 +10,6 @@ on:
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
-    if: github.repository == 'Div0011/mowglai'
     permissions:
       contents: read
 
@@ -52,8 +51,8 @@ jobs:
       # CD (Continuous Deployment) Pipeline
       # ==========================================
       - name: Sync files to Hostinger via SSH
-        # Only deploy on push to main
-        if: github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
+        # Only deploy on push to main and if we are in the original repository
+        if: github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.repository_owner == 'Div0011'
         uses: burnett01/rsync-deployments@8.0.4
         with:
           switches: "-avzr --exclude '.next' --exclude 'node_modules' --exclude '.git'"


### PR DESCRIPTION
## Summary by Sourcery

Adjust CI/CD workflow conditions to always run the pipeline but restrict the deploy step to the original repository owner.

CI:
- Remove the repository-level condition so the CI/CD job runs for all forks.
- Tighten the deploy step condition so deployment only occurs from the main branch in the original Div0011-owned repository.